### PR TITLE
Unblock baidupan download link generation

### DIFF
--- a/Auto/REJECT.conf
+++ b/Auto/REJECT.conf
@@ -616,7 +616,6 @@ DOMAIN-SUFFIX,rigel.baidustatic.com,REJECT
 DOMAIN-SUFFIX,river.zhidao.baidu.com,REJECT
 DOMAIN-SUFFIX,rj.baidu.com,REJECT
 DOMAIN-SUFFIX,rplog.baidu.com,REJECT
-DOMAIN-SUFFIX,s.baidu.com,REJECT
 DOMAIN-SUFFIX,s.cpro.baidu.com,REJECT
 DOMAIN-SUFFIX,sa.tuisong.baidu.com,REJECT
 DOMAIN-SUFFIX,sclick.baidu.com,REJECT

--- a/Quantumult/Quantumult.conf
+++ b/Quantumult/Quantumult.conf
@@ -709,7 +709,6 @@ DOMAIN-SUFFIX,rigel.baidustatic.com,REJECT
 DOMAIN-SUFFIX,river.zhidao.baidu.com,REJECT
 DOMAIN-SUFFIX,rj.baidu.com,REJECT
 DOMAIN-SUFFIX,rplog.baidu.com,REJECT
-DOMAIN-SUFFIX,s.baidu.com,REJECT
 DOMAIN-SUFFIX,s.cpro.baidu.com,REJECT
 DOMAIN-SUFFIX,sa.tuisong.baidu.com,REJECT
 DOMAIN-SUFFIX,sclick.baidu.com,REJECT

--- a/Shadowrocket.conf
+++ b/Shadowrocket.conf
@@ -672,7 +672,6 @@ DOMAIN-SUFFIX,rigel.baidustatic.com,REJECT
 DOMAIN-SUFFIX,river.zhidao.baidu.com,REJECT
 DOMAIN-SUFFIX,rj.baidu.com,REJECT
 DOMAIN-SUFFIX,rplog.baidu.com,REJECT
-DOMAIN-SUFFIX,s.baidu.com,REJECT
 DOMAIN-SUFFIX,s.cpro.baidu.com,REJECT
 DOMAIN-SUFFIX,sa.tuisong.baidu.com,REJECT
 DOMAIN-SUFFIX,sclick.baidu.com,REJECT

--- a/Surge.conf
+++ b/Surge.conf
@@ -708,7 +708,6 @@ DOMAIN-SUFFIX,rigel.baidustatic.com,REJECT
 DOMAIN-SUFFIX,river.zhidao.baidu.com,REJECT
 DOMAIN-SUFFIX,rj.baidu.com,REJECT
 DOMAIN-SUFFIX,rplog.baidu.com,REJECT
-DOMAIN-SUFFIX,s.baidu.com,REJECT
 DOMAIN-SUFFIX,s.cpro.baidu.com,REJECT
 DOMAIN-SUFFIX,sa.tuisong.baidu.com,REJECT
 DOMAIN-SUFFIX,sclick.baidu.com,REJECT


### PR DESCRIPTION
Unblock d.pcs.baidu.com, which is related to download link, like `https://d11.baidupcs.com/file/dummy`s, generation from pan.baidu.com.