### PR TITLE
修复知乎日报图片误伤

### DIFF
--- a/Quantumult/Quantumult_URL.conf
+++ b/Quantumult/Quantumult_URL.conf
@@ -29,7 +29,6 @@ hostname = *.bdimg.com,*.byteoversea.com,*.cnbetacdn.com,*.dy103.com,*.pstatp.co
 ^https?:\/\/impservice\..+\.youdao.com - reject
 ^https?:\/\/log\..+\.baidu\.com - reject
 ^https?:\/\/notice\.send-anywhere\.com\/banner - reject
-^https?:\/\/pic\d\.zhimg\.com\/v2.+ - reject
 ^https?:\/\/sa\d\.tuisong\.baidu\.com - reject
 ^https?:\/\/sax\d\.sina\.com\.cn - reject
 ^https?:\/\/sax\w?\.sina\.cn - reject


### PR DESCRIPTION
知乎日报正文中的图片会被误伤，比如 https://daily.zhihu.com/story/9699778 中的 https://pic3.zhimg.com/v2-a3242822b6d25cef0983fe6a4daaa604_b.jpg