### PR TITLE
Update DIRECT.conf

### DIFF
--- a/Auto/DIRECT.conf
+++ b/Auto/DIRECT.conf
@@ -57,7 +57,6 @@ DOMAIN-SUFFIX,edu.cn,🍂 Domestic
 DOMAIN-SUFFIX,steamcontent.com,🍂 Domestic
 
 // TeamViewer
-IP-CIDR,109.239.140.0/24,🍂 Domestic,no-resolve
 IP-CIDR,139.220.243.27/32,🍂 Domestic,no-resolve
 IP-CIDR,172.16.102.56/32,🍂 Domestic,no-resolve
 IP-CIDR,185.188.32.1/28,🍂 Domestic,no-resolve


### PR DESCRIPTION
The rule for Teamveiwer
"IP-CIDR,109.239.140.0/24,🍂 Domestic,no-resolve"
is confict with Telegram