### PR TITLE
Update global_media.list

### DIFF
--- a/Surge3/global_media.list
+++ b/Surge3/global_media.list
@@ -107,7 +107,4 @@ DOMAIN-SUFFIX,spoti.fi
 DOMAIN-SUFFIX,viu.tv
 
 // Youtube
-DOMAIN-KEYWORD,youtube
-DOMAIN-SUFFIX,googlevideo.com
-DOMAIN-SUFFIX,gvt2.com
-DOMAIN-SUFFIX,youtu.be
+DOMAIN-SUFFIX,youtubei.googleapis.com


### PR DESCRIPTION
针对YouTube只改动这一行可继续使用Proxy内的节点如香港日本这类低延迟线路，但同时可以通过premium这类的ip验证，实现去广告和后台播放