### PR TITLE
Move Rule for Pandora to Media List

### DIFF
--- a/Surge3/apple.list
+++ b/Surge3/apple.list
@@ -2,6 +2,8 @@ USER-AGENT,*com.apple.mobileme.fmip1
 USER-AGENT,*WeatherFoundation*
 USER-AGENT,%E5%9C%B0%E5%9B%BE*
 USER-AGENT,%E8%AE%BE%E7%BD%AE*
+USER-AGENT,AppStore*
+USER-AGENT,com.apple.appstored*
 USER-AGENT,com.apple.geod*
 USER-AGENT,com.apple.Maps
 USER-AGENT,FindMyFriends*
@@ -12,6 +14,11 @@ USER-AGENT,fmflocatord*
 USER-AGENT,geod*
 USER-AGENT,locationd*
 USER-AGENT,Maps*
+USER-AGENT,TestFlight*
 DOMAIN-SUFFIX,apple.com
-DOMAIN,api.smoot.apple.cn
+DOMAIN,api.smoot.apple.cnA
+DOMAIN-SUFFIX,icloud.com
+DOMAIN-SUFFIX,itunes.com
+DOMAIN-SUFFIX,me.com
+DOMAIN-SUFFIX,mzstatic.com
 PROCESS-NAME,trustd

--- a/Surge3/apple.list
+++ b/Surge3/apple.list
@@ -16,7 +16,7 @@ USER-AGENT,locationd*
 USER-AGENT,Maps*
 USER-AGENT,TestFlight*
 DOMAIN-SUFFIX,apple.com
-DOMAIN,api.smoot.apple.cnA
+DOMAIN,api.smoot.apple.cn
 DOMAIN-SUFFIX,icloud.com
 DOMAIN-SUFFIX,itunes.com
 DOMAIN-SUFFIX,me.com

--- a/Surge3/global_media.list
+++ b/Surge3/global_media.list
@@ -94,6 +94,9 @@ DOMAIN-SUFFIX,nflximg.net
 DOMAIN-SUFFIX,nflxso.net
 DOMAIN-SUFFIX,nflxvideo.net
 
+// Pandora
+DOMAIN-SUFFIX,pandora.com
+
 // SoundCloud
 USER-AGENT,SoundCloud*
 

--- a/Surge3/proxy.list
+++ b/Surge3/proxy.list
@@ -360,7 +360,6 @@ DOMAIN-SUFFIX,osxdaily.com
 DOMAIN-SUFFIX,ow.ly
 DOMAIN-SUFFIX,paddle.com
 DOMAIN-SUFFIX,paddleapi.com
-DOMAIN-SUFFIX,pandora.com
 DOMAIN-SUFFIX,panoramio.com
 DOMAIN-SUFFIX,parallels.com
 DOMAIN-SUFFIX,parse.com


### PR DESCRIPTION
"Pandora.com" was in the proxy.list, but that is a US based media service.