### PR TITLE
fix reject.list since the regex rule with stat word may injure the url with static word in it.

### DIFF
--- a/Surge3/Reject.list
+++ b/Surge3/Reject.list
@@ -8331,7 +8331,7 @@ URL-REGEX,https?://[^bbs].tianya\.cn
 URL-REGEX,https?://\w.?up.qingdaonews.com
 URL-REGEX,https?://\w{6}.com1.z0.glb.clouddn.com
 URL-REGEX,https?://\w{8}.logic.cpm.cm.kankan.com
-URL-REGEX,https?://\w+.?(ad(s)?|log\w?|tj|tongji|stat\w+?|\w+?trac(e|k)?|click).\w+
+URL-REGEX,https?://\w+.?(ad(s)?|log\w?|tj|tongji|((?!static)stat\w+?)|\w+?trac(e|k)?|click).\w+
 URL-REGEX,https?://\w+.beacon.qq.com
 URL-REGEX,https?://\w+.cloudfront.net/banner
 URL-REGEX,https?://\w+.gdt.qq.com


### PR DESCRIPTION
stat\w+?这个感觉太容易误伤到static了，希望能够排除掉static的情况

- ***-static.
- cdn.static.

这种url还比较常见吧，现在直接reject了感觉不太好