### PR TITLE
Add support of YouTube Music

### DIFF
--- a/Surge3/Media/Youtube_Music_for_iOS.list
+++ b/Surge3/Media/Youtube_Music_for_iOS.list
@@ -1,3 +1,4 @@
 # > Youtube_Music_for_iOS
 USER-AGENT,*YouTubeMusic*
 USER-AGENT,*com.google.ios.youtubemusic*
+#PROCESS-NAME,YT Music

--- a/Surge3/Media/Youtube_Music_for_iOS.list
+++ b/Surge3/Media/Youtube_Music_for_iOS.list
@@ -1,0 +1,3 @@
+# > Youtube_Music_for_iOS
+USER-AGENT,*YouTubeMusic*
+USER-AGENT,*com.google.ios.youtubemusic*


### PR DESCRIPTION
The YouTube provide service for almost every area of the world. But only some areas provide YouTube Music service. For example, some people may visit YouTube by HK Proxy for higher speed, but the YouTube Music doesn't work in HongKong, visit the YouTube Music by US proxy respectively should be better.

However, these rules only work properly for the App, YouTube Music for iOS. Because there are some resource paths of YouTube Music which are similar with YouTube, the video site. The USER-AGENT rule is a better way to avoid the conflict with YouTube Ruleset. 

For Mac User, using the unofficial client such as YT-Music could be a way. Just uncomment the line below:

> PROCESS-NAME,YT Music