### PR TITLE
误杀今日头条和西瓜视频的部分内容

### DIFF
--- a/Auto/Hostname.conf
+++ b/Auto/Hostname.conf
@@ -102,7 +102,6 @@ impservice.youdao.com
 interface.music.163.com
 ios.wps.cn
 kano.guahao.cn
-lf.snssdk.com
 lives.l.qq.com
 m.aty.sohu.com
 m.client.10010.com


### PR DESCRIPTION
把 lf.snssdk.com 从主机名中去除掉，因为它会导致西瓜视频关注的内容加载不出来。