### PR TITLE
Add BT service from Thunder into Direct rule

### DIFF
--- a/Auto/DIRECT.conf
+++ b/Auto/DIRECT.conf
@@ -4,6 +4,7 @@
 PROCESS-NAME,Paws for Trello,🍂 Domestic
 PROCESS-NAME,ss-local,🍂 Domestic
 PROCESS-NAME,Thunder,🍂 Domestic
+PROCESS-NAME,DownloadService,🍂 Domestic
 PROCESS-NAME,TeamViewer,🍂 Domestic
 PROCESS-NAME,trustd,🍂 Domestic
 PROCESS-NAME,WebTorrent,🍂 Domestic


### PR DESCRIPTION
`DownloadService`, a service used for BT downloading in Thunder is added. At least, it exists in the latest thunder v3.3.4.