### PR TITLE
delete cloudflare from proxy list

### DIFF
--- a/Clash/Rule.yml
+++ b/Clash/Rule.yml
@@ -894,8 +894,6 @@ Rule:
 # > ChinaNetCenter
 - DOMAIN-SUFFIX,chinanetcenter.com,Domestic
 - DOMAIN-SUFFIX,wangsu.com,Domestic
-# > CloudFlare
-- DOMAIN-SUFFIX,cloudflare.com,Domestic
 # > IP Query
 - DOMAIN-SUFFIX,ipip.net,Domestic
 - DOMAIN-SUFFIX,ip.cn,Domestic


### PR DESCRIPTION
cloudflare.com is not the cdn domain for cloudflare, as the homepage, the access speed is very slow in mainland china.