### PR TITLE
Remove conflicting domain live.com from Auto/Direct.conf

### DIFF
--- a/Auto/DIRECT.conf
+++ b/Auto/DIRECT.conf
@@ -183,7 +183,6 @@ DOMAIN-SUFFIX,lecloud.com,🍂 Domestic
 DOMAIN-SUFFIX,lemicp.com,🍂 Domestic
 DOMAIN-SUFFIX,letv.com,🍂 Domestic
 DOMAIN-SUFFIX,letvcloud.com,🍂 Domestic
-DOMAIN-SUFFIX,live.com,🍂 Domestic
 DOMAIN-SUFFIX,lizhi.io,🍂 Domestic
 DOMAIN-SUFFIX,localizecdn.com,🍂 Domestic
 DOMAIN-SUFFIX,lucifr.com,🍂 Domestic


### PR DESCRIPTION
`live.com` already exists in `Auto/PROXY.conf`. Remove it from `Auto/DIRECT.conf`.