### PR TITLE
将 suggestqueries.google.com 从 Reject 列表中移除

### DIFF
--- a/DlerCloud/Rule_2.conf
+++ b/DlerCloud/Rule_2.conf
@@ -7048,7 +7048,6 @@ DOMAIN-SUFFIX,sub.topber.com,AdBlock
 DOMAIN-SUFFIX,subswin.com,AdBlock
 DOMAIN-SUFFIX,sucodb.com,AdBlock
 DOMAIN-SUFFIX,sugar.zhihu.com,AdBlock
-DOMAIN-SUFFIX,suggestqueries.google.com,AdBlock
 DOMAIN-SUFFIX,sunjianhao.com,AdBlock
 DOMAIN-SUFFIX,suoooi.cn,AdBlock
 DOMAIN-SUFFIX,super.cat898.com,AdBlock

--- a/Shadowrocket.conf
+++ b/Shadowrocket.conf
@@ -7021,7 +7021,6 @@ DOMAIN-SUFFIX,sub.topber.com,REJECT
 DOMAIN-SUFFIX,subswin.com,REJECT
 DOMAIN-SUFFIX,sucodb.com,REJECT
 DOMAIN-SUFFIX,sugar.zhihu.com,REJECT
-DOMAIN-SUFFIX,suggestqueries.google.com,REJECT
 DOMAIN-SUFFIX,sunjianhao.com,REJECT
 DOMAIN-SUFFIX,suoooi.cn,REJECT
 DOMAIN-SUFFIX,super.cat898.com,REJECT

--- a/Surge3/Reject.list
+++ b/Surge3/Reject.list
@@ -7004,7 +7004,6 @@ DOMAIN-SUFFIX,sub.topber.com
 DOMAIN-SUFFIX,subswin.com
 DOMAIN-SUFFIX,sucodb.com
 DOMAIN-SUFFIX,sugar.zhihu.com
-DOMAIN-SUFFIX,suggestqueries.google.com
 DOMAIN-SUFFIX,sunjianhao.com
 DOMAIN-SUFFIX,suoooi.cn
 DOMAIN-SUFFIX,super.cat898.com


### PR DESCRIPTION
`suggestqueries.google.com` 提供了 Google 的模糊补全，两处参考：

- [Google Suggest API](https://stackoverflow.com/questions/5102878/google-suggest-api) Stack Overflow
- [Google Autocomplete "API"](https://shreyaschand.com/blog/2013/01/03/google-autocomplete-api/)
