### PR TITLE
move v2ex to proxy list

### DIFF
--- a/Surge3/Domestic.list
+++ b/Surge3/Domestic.list
@@ -244,7 +244,6 @@ DOMAIN-SUFFIX,umengcloud.com
 DOMAIN-SUFFIX,upaiyun.com
 DOMAIN-SUFFIX,upyun.com
 DOMAIN-SUFFIX,uxengine.net
-DOMAIN-SUFFIX,v2ex.com
 DOMAIN-SUFFIX,wandoujia.com
 DOMAIN-SUFFIX,weather.bjango.com
 DOMAIN-SUFFIX,weather.com

--- a/Surge3/Proxy.list
+++ b/Surge3/Proxy.list
@@ -694,6 +694,9 @@ DOMAIN-SUFFIX,waveprotocol.org
 DOMAIN-SUFFIX,webmproject.org
 DOMAIN-SUFFIX,webrtc.org
 
+# > V2EX
+DOMAIN-SUFFIX,v2ex.com
+
 DOMAIN-KEYWORD,dlercloud
 DOMAIN-SUFFIX,dler.cloud
 


### PR DESCRIPTION
According to [post](https://www.v2ex.com/t/580480#reply176) on V2EX by livid

Quote here

```
On recent change of this website's infrastructure
For easier updating the code of this site, as the sole developer based in the U.S., I moved the server
and CDN of this website to California. Since China infrastructure is no longer part of the site, loading
performance may degrade for visitors from China mainland. Also, this website is no longer eligible for
China's ICP filing.

No need to over-interpret this. I'm tired. Just want to have a good sleep in local timezone.

Thanks.
```

`v2ex.com` should be moved to proxy list.

