### PR TITLE
Add ieee.org to Domestic

### DIFF
--- a/Clash/Rule.yml
+++ b/Clash/Rule.yml
@@ -903,6 +903,7 @@ Rule:
 - DOMAIN-SUFFIX,whatismyip.com,Domestic
 - DOMAIN,ip.bjango.com,Domestic
 # > Other
+- DOMAIN-SUFFIX,ieee.org,Domestic
 - DOMAIN-SUFFIX,40017.cn,Domestic
 - DOMAIN-SUFFIX,broadcasthe.net,Domestic
 - DOMAIN-SUFFIX,cailianpress.com,Domestic


### PR DESCRIPTION
When we download some academic papers from IEEE, we should login IEEE.org as an institution if we use the university network environment. So we should connect to the ieee.org directly.