### PR TITLE
Fix：QQ达人天数显示

### DIFF
--- a/Auto/URL Rewrite.conf
+++ b/Auto/URL Rewrite.conf
@@ -32,7 +32,7 @@ https?://cnzz.com/ http://ogtre5vp0.bkt.clouddn.com/background.png? header
 https?://m.qu.la/stylewap/js/wap.js http://ogtre5vp0.bkt.clouddn.com/qu_la_wap.js 302
 https?://m.yhd.com/1/\? http://m.yhd.com/1/?adbock= 302
 https?://n.mark.letv.com/m3u8api/ http://burpsuite.applinzi.com/Interface header
-https?://sqimg.qq.com/ https://sqimg.qq.com/ 302
+https?://sqimg.qq.com/ http://sqimg.qq.com/ 302
 https?://static.m.ttkvod.com/static_cahce/index/index.txt http://ogtre5vp0.bkt.clouddn.com/Static/TXT/index.txt header
 https?://www.iqshw.com/d/js/m http://burpsuite.applinzi.com/Interface header
 https?://www.iqshw.com/d/js/m http://rewrite.websocket.site:10/Other/Static/JS/Package.js? header


### PR DESCRIPTION
原来Rewrite成https会导致QQ中QQ达人连续登录天数无法正常加载，改为http即可恢复正常。