### PR TITLE
add k8s.io to Proxy

### DIFF
--- a/Clash/Rule.yml
+++ b/Clash/Rule.yml
@@ -415,6 +415,7 @@ Rule:
 - DOMAIN-SUFFIX,jshint.com,Proxy
 - DOMAIN-SUFFIX,jtvnw.net,Proxy
 - DOMAIN-SUFFIX,justgetflux.com,Proxy
+- DOMAIN,k8s.io,Proxy
 - DOMAIN-SUFFIX,kat.cr,Proxy
 - DOMAIN-SUFFIX,klip.me,Proxy
 - DOMAIN-SUFFIX,libsyn.com,Proxy


### PR DESCRIPTION
BTW, ```k8s.io``` is permanatly redirected to ```kubernetes.io```(which is not blocked currently), to be conservative enough, just add ```k8s.io```.