### PR TITLE
fix bug

### DIFF
--- a/Surge/Surge 3/Provider/Netease Music.list
+++ b/Surge/Surge 3/Provider/Netease Music.list
@@ -1,16 +1,22 @@
 # > NeteaseMusic
-DOMAIN,music.163.com
-DOMAIN,interface.music.163.com
-DOMAIN,interface3.music.163.com
-DOMAIN,apm.music.163.com
 DOMAIN,apm3.music.163.com
+DOMAIN,apm.music.163.com
+DOMAIN,interface3.music.163.com
+DOMAIN,interface.music.163.com
+DOMAIN,music.163.com
 IP-CIDR,39.105.63.80/32,no-resolve
+IP-CIDR,45.254.48.1/32,no-resolve
 IP-CIDR,47.100.127.239/32,no-resolve
 IP-CIDR,59.111.160.195/32,no-resolve
 IP-CIDR,59.111.160.197/32,no-resolve
 IP-CIDR,59.111.181.35/32,no-resolve
 IP-CIDR,59.111.181.38/32,no-resolve
 IP-CIDR,59.111.181.60/32,no-resolve
+IP-CIDR,101.71.154.241/32,no-resolve
+IP-CIDR,103.126.92.132/32,no-resolve
+IP-CIDR,103.126.92.133/32,no-resolve
+IP-CIDR,112.13.119.17/32,no-resolve
+IP-CIDR,112.13.122.1/32,no-resolve
 IP-CIDR,115.236.118.33/32,no-resolve
 IP-CIDR,115.236.121.1/32,no-resolve
 IP-CIDR,118.24.63.156/32,no-resolve

--- a/Surge/Surge 3/Provider/Netease Music.list
+++ b/Surge/Surge 3/Provider/Netease Music.list
@@ -1,5 +1,19 @@
 # > NeteaseMusic
-USER-AGENT,%E7%BD%91%E6%98%93%E4%BA%91%E9%9F%B3%E4%B9%90
-USER-AGENT,NeteaseMusic*
-DOMAIN-SUFFIX,music.126.net
-DOMAIN-SUFFIX,music.163.com
+DOMAIN,music.163.com
+DOMAIN,interface.music.163.com
+DOMAIN,interface3.music.163.com
+DOMAIN,apm.music.163.com
+DOMAIN,apm3.music.163.com
+IP-CIDR,39.105.63.80/32,no-resolve
+IP-CIDR,47.100.127.239/32,no-resolve
+IP-CIDR,59.111.160.195/32,no-resolve
+IP-CIDR,59.111.160.197/32,no-resolve
+IP-CIDR,59.111.181.35/32,no-resolve
+IP-CIDR,59.111.181.38/32,no-resolve
+IP-CIDR,59.111.181.60/32,no-resolve
+IP-CIDR,115.236.118.33/32,no-resolve
+IP-CIDR,115.236.121.1/32,no-resolve
+IP-CIDR,118.24.63.156/32,no-resolve
+IP-CIDR,193.112.159.225/32,no-resolve
+IP-CIDR,223.252.199.66/32,no-resolve
+IP-CIDR,223.252.199.67/32,no-resolve


### PR DESCRIPTION
由于服务器只对这些连接进行hook，因此不必将网易云音乐整个客户端的连接代理，而导致出现某些非破解音乐播放不正常。详细可见https://github.com/nondanee/UnblockNeteaseMusic/blob/91e631db87920c67f92161a724a2d96472ad33cd/src/hook.js   中的    hook.target.host