### PR TITLE
Fix Wi-Fi that requires authentication on Windows

### DIFF
--- a/Clash/Rule.yaml
+++ b/Clash/Rule.yaml
@@ -9699,6 +9699,7 @@
 - DOMAIN-SUFFIX,windows.net,Microsoft
 - DOMAIN-SUFFIX,xbox.com,Microsoft
 - DOMAIN-SUFFIX,xboxlive.com,Microsoft
+- DOMAIN-SUFFIX,msftconnecttest.com,DIRECT
 
 
 


### PR DESCRIPTION
If a Wi-Fi hotspot requires users to sign in, Windows will open a browser window automatically and redirect users to http://www.msftconnecttest.com/redirect. Without the proposed rule, this page will fail to load because clash cannot connect to the Internet yet.