### PR TITLE
add disney.my.sentry.io for disney plus

### DIFF
--- a/Clash/Provider/Media/Disney Plus.yaml
+++ b/Clash/Provider/Media/Disney Plus.yaml
@@ -3,6 +3,7 @@ payload:
   # - User-Agent,Disney*
   - DOMAIN,cdn.registerdisney.go.com
   - DOMAIN,cdn.cdn.unid.go.com
+  - DOMAIN,disney.my.sentry.io
   - DOMAIN-SUFFIX,bamgrid.com
   - DOMAIN-SUFFIX,braze.com
   - DOMAIN-SUFFIX,conviva.com


### PR DESCRIPTION
this is a domain used by disney plus IOS client
![photo_2020-10-06_08-36-14](https://user-images.githubusercontent.com/1171298/95145912-046f3400-07af-11eb-99bb-ca058bbae92c.jpg)
