### PR TITLE
Add PROCESS-NAME rules for CFW

### DIFF
--- a/Clash/Provider/Special.yaml
+++ b/Clash/Provider/Special.yaml
@@ -54,6 +54,18 @@ payload:
   - DOMAIN-SUFFIX,xunlei.com
 
   # > Download
+  - PROCESS-NAME,aria2c.exe
+  - PROCESS-NAME,BitComet.exe
+  - PROCESS-NAME,fdm.exe
+  # - PROCESS-NAME,IDMan.exe
+  - PROCESS-NAME,NetTransport.exe
+  - PROCESS-NAME,qbittorrent.exe
+  - PROCESS-NAME,Thunder.exe
+  - PROCESS-NAME,ThunderVIP.exe
+  - PROCESS-NAME,transmission-daemon.exe
+  - PROCESS-NAME,transmission-qt.exe
+  - PROCESS-NAME,uTorrent.exe
+  - PROCESS-NAME,WebTorrent.exe
   - PROCESS-NAME,aria2c
   - PROCESS-NAME,fdm
   - PROCESS-NAME,Folx


### PR DESCRIPTION
对于 Clash for Windows v0.11.5 及以上版本，使用PROCESS-NAME规则需要匹配完整的进程名（包括可执行文件后缀）方可生效。
考虑到IDM被广泛用于Google Drive等境外存储服务，默认不作匹配。