### PR TITLE
Add a specific ruleset for LAN

### DIFF
--- a/Clash/Provider/LAN.yaml
+++ b/Clash/Provider/LAN.yaml
@@ -1,0 +1,9 @@
+payload:
+  - DOMAIN-SUFFIX,local
+  - IP-CIDR,127.0.0.0/8
+  - IP-CIDR,172.16.0.0/12
+  - IP-CIDR,192.168.0.0/16
+  - IP-CIDR,10.0.0.0/8
+  - IP-CIDR,17.0.0.0/8
+  - IP-CIDR,100.64.0.0/10
+  - IP-CIDR6,fe80::/10

--- a/Clash/Provider/Special.yaml
+++ b/Clash/Provider/Special.yaml
@@ -107,9 +107,3 @@ payload:
   - DOMAIN-SUFFIX,smtp
   # - URL-REGEX,(Subject|HELO|SMTP)
 
-  - DOMAIN-SUFFIX,local
-  - IP-CIDR,127.0.0.0/8
-  - IP-CIDR,172.16.0.0/12
-  - IP-CIDR,192.168.0.0/16
-  - IP-CIDR,10.0.0.0/8
-  - IP-CIDR,100.64.0.0/10

--- a/Clash/Rule.yaml
+++ b/Clash/Rule.yaml
@@ -55,6 +55,7 @@
 - RULE-SET,Domestic,Domestic
 - RULE-SET,Domestic IPs,Domestic
 
+- RULE-SET,LAN,DIRECT
 - GEOIP,CN,Domestic
 - MATCH,Others
 
@@ -420,4 +421,10 @@ rule-providers:
     behavior: ipcidr
     url: 'https://gitee.com/lhie1/Rules/raw/master/Clash/Provider/Domestic%20IPs.yaml'
     path: ./Rules/Domestic_IPs
+    interval: 86400
+  LAN:
+    type: http
+    behavior: classical
+    url: 'https://gitee.com/lhie1/Rules/raw/master/Clash/Provider/LAN.yaml'
+    path: ./Rules/LAN
     interval: 86400


### PR DESCRIPTION
现版本局域网地址位于Special.yaml，在规则中过于靠前。
将这些地址放到GeoIP规则之前，与Surge规则保持一致。