### PR TITLE
Fix LAN match in script mode

### DIFF
--- a/Clash/Rule.yaml
+++ b/Clash/Rule.yaml
@@ -108,7 +108,8 @@ script:
             "PROXY": "Proxy",
             "Apple": "Apple",
             "Domestic": "Domestic",
-            "Domestic IPs": "Domestic"
+            "Domestic IPs": "Domestic",
+            "LAN": "DIRECT"
             }
         port = int(metadata["dst_port"])
 
@@ -125,8 +126,6 @@ script:
           return "DIRECT"
 
         code = ctx.geoip(ip)
-        if code == "LAN":
-          return "DIRECT"
 
         if code == "CN":
           return "Domestic"


### PR DESCRIPTION
由于 @Hackl0us 的GeoIP2数据库没有包含LAN地址，当使用该数据库时，脚本模式下基于GeoIP的匹配方式将失效。
修改为基于ruleset的匹配方式。