### PR TITLE
Remove music.126.net

### DIFF
--- a/Surge/Surge 2/Rule.conf
+++ b/Surge/Surge 2/Rule.conf
@@ -8487,7 +8487,6 @@ DOMAIN,apm.music.163.com,AsianTV
 DOMAIN,apm3.music.163.com,AsianTV
 DOMAIN,interface.music.163.com,AsianTV
 DOMAIN,interface3.music.163.com,AsianTV
-DOMAIN,music.126.net,AsianTV
 DOMAIN,music.163.com,AsianTV
 IP-CIDR,101.71.154.241/32,AsianTV,no-resolve
 IP-CIDR,103.126.92.132/32,AsianTV,no-resolve

--- a/Surge/Surge 3/Provider/Media/Netease Music.list
+++ b/Surge/Surge 3/Provider/Media/Netease Music.list
@@ -3,7 +3,6 @@ DOMAIN,apm.music.163.com
 DOMAIN,apm3.music.163.com
 DOMAIN,interface.music.163.com
 DOMAIN,interface3.music.163.com
-DOMAIN,music.126.net
 DOMAIN,music.163.com
 IP-CIDR,101.71.154.241/32,no-resolve
 IP-CIDR,103.126.92.132/32,no-resolve


### PR DESCRIPTION
`music.126.net` is the domain of **static resources, like album photos and musics that are available** on Netease Music, therefore shouldn't be proxied.
Proxying it is OK but **not perfect enough, for this will make things a little bit slower**.