### PR TITLE
fix Netflix.yaml

### DIFF
--- a/Clash/Provider/Media/Netflix.yaml
+++ b/Clash/Provider/Media/Netflix.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Netflix
-  - USER-AGENT,Argo*
+  - PROCESS-NAME,Argo*
   - DOMAIN-KEYWORD,netflix
   - DOMAIN,netflix.com.edgesuite.net
   - DOMAIN-SUFFIX,netflix.com


### PR DESCRIPTION
clash doesn't support the rule `USER-AGENT`, `PROCESS-NAME` may be an alternative