### PR TITLE
Restore most of the PROCESS-NAME rules for Clash

### DIFF
--- a/Clash/Provider/Apple.yaml
+++ b/Clash/Provider/Apple.yaml
@@ -27,4 +27,4 @@ payload:
   - DOMAIN-SUFFIX,apple.news
 
   # > Apple Maps
-  # - PROCESS-NAME,com.apple.geod
+  - PROCESS-NAME,com.apple.geod

--- a/Clash/Provider/Domestic.yaml
+++ b/Clash/Provider/Domestic.yaml
@@ -3,7 +3,7 @@ payload:
   - DOMAIN-KEYWORD,beplay
 
   # > Blizzard
-  # - User-Agent,hearthstone*
+  # - USER-AGENT,hearthstone*
   - DOMAIN,cdp.cloud.unity3d.com
   - DOMAIN-SUFFIX,battle.net
   - DOMAIN-SUFFIX,battlenet.com
@@ -20,7 +20,7 @@ payload:
   - DOMAIN-SUFFIX,zmzfile.com
 
   # > Sony
-  # - User-Agent,RemotePlay*
+  # - USER-AGENT,RemotePlay*
   - DOMAIN-SUFFIX,playstation.com
   - DOMAIN-SUFFIX,playstation.net
   - DOMAIN-SUFFIX,playstationnetwork.com

--- a/Clash/Provider/Media/Abema TV.yaml
+++ b/Clash/Provider/Media/Abema TV.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > AbemaTV
-  # - User-Agent,AbemaTV*
+  # - USER-AGENT,AbemaTV*
   - DOMAIN-SUFFIX,abema.io
   - DOMAIN-SUFFIX,abema.tv
   - DOMAIN-SUFFIX,akamaized.net

--- a/Clash/Provider/Media/Amazon.yaml
+++ b/Clash/Provider/Media/Amazon.yaml
@@ -1,7 +1,7 @@
 payload:  
   # > Amazon Prime Video
-  # - User-Agent,InstantVideo.US*
-  # - User-Agent,Prime%20Video*
+  # - USER-AGENT,InstantVideo.US*
+  # - USER-AGENT,Prime%20Video*
   - DOMAIN-SUFFIX,aiv-cdn.net
   - DOMAIN-SUFFIX,amazonaws.co.uk
   - DOMAIN-SUFFIX,amazonaws.com

--- a/Clash/Provider/Media/Apple News.yaml
+++ b/Clash/Provider/Media/Apple News.yaml
@@ -1,12 +1,12 @@
 payload:  
   # > Apple News and Apple Map TOMTOM Version
-  # - User-Agent,AppleNews*
-  # - User-Agent,com.apple.news*
+  # - USER-AGENT,AppleNews*
+  # - USER-AGENT,com.apple.news*
   - DOMAIN,gspe1-ssl.ls.apple.com
-  # USER-AGENT,News*
-  # DOMAIN,apple.comscoreresearch.com
-  # DOMAIN,gateway.icloud.com
-  # DOMAIN,news-client.apple.com
-  # DOMAIN,news-edge.apple.com
-  # DOMAIN,news-events.apple.com
-  # DOMAIN-SUFFIX,apple.news
+  # - USER-AGENT,News*
+  # - DOMAIN,apple.comscoreresearch.com
+  # - DOMAIN,gateway.icloud.com
+  # - DOMAIN,news-client.apple.com
+  # - DOMAIN,news-edge.apple.com
+  # - DOMAIN,news-events.apple.com
+  # - DOMAIN-SUFFIX,apple.news

--- a/Clash/Provider/Media/BBC iPlayer.yaml
+++ b/Clash/Provider/Media/BBC iPlayer.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > BBC iPlayer
-  # - User-Agent,BBCiPlayer*
+  # - USER-AGENT,BBCiPlayer*
   - DOMAIN-KEYWORD,bbcfmt
   - DOMAIN,aod-dash-uk-live.akamaized.net
   - DOMAIN,aod-hls-uk-live.akamaized.net

--- a/Clash/Provider/Media/Bahamut.yaml
+++ b/Clash/Provider/Media/Bahamut.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Bahamut
-  # - User-Agent,Anime*
+  # - USER-AGENT,Anime*
   - DOMAIN-SUFFIX,bahamut.com.tw
   - DOMAIN-SUFFIX,gamer.com.tw
   - DOMAIN-SUFFIX,hinet.net

--- a/Clash/Provider/Media/Bilibili.yaml
+++ b/Clash/Provider/Media/Bilibili.yaml
@@ -1,7 +1,7 @@
 payload:  
   # > Bilibili
-  # - User-Agent,bili*
-  # - User-Agent,Bilibili*
+  # - USER-AGENT,bili*
+  # - USER-AGENT,Bilibili*
   - DOMAIN-SUFFIX,acg.tv
   - DOMAIN-SUFFIX,acgvideo.com
   - DOMAIN-SUFFIX,b23.tv

--- a/Clash/Provider/Media/Discovery Plus.yaml
+++ b/Clash/Provider/Media/Discovery Plus.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Discovery Plus
-  # - User-Agent,DPlus*
+  # - USER-AGENT,DPlus*
   - DOMAIN-SUFFIX,content-ause1-ur-discovery1.uplynk.com
   - DOMAIN-SUFFIX,disco-api.com
   - DOMAIN-SUFFIX,discoveryplus.com

--- a/Clash/Provider/Media/Disney Plus.yaml
+++ b/Clash/Provider/Media/Disney Plus.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Disney Plus
-  # - User-Agent,Disney*
+  # - USER-AGENT,Disney*
   - DOMAIN-SUFFIX,adobedtm.com
   - DOMAIN-SUFFIX,bam.nr-date.net
   - DOMAIN-SUFFIX,bamgrid.com

--- a/Clash/Provider/Media/Fox Now.yaml
+++ b/Clash/Provider/Media/Fox Now.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Fox Now
-  # - User-Agent,FOX%20NOW*
+  # - USER-AGENT,FOX%20NOW*
   - DOMAIN-SUFFIX,fox.com
   - DOMAIN-SUFFIX,foxdcg.com
   - DOMAIN-SUFFIX,uplynk.com

--- a/Clash/Provider/Media/Fox+.yaml
+++ b/Clash/Provider/Media/Fox+.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Fox+ (HK|TW|SG)
-  # - User-Agent,FOXPlus*
+  # - USER-AGENT,FOXPlus*
   - DOMAIN-SUFFIX,akamaized.net
   - DOMAIN-SUFFIX,foxplus.com
   - DOMAIN-SUFFIX,theplatform.com

--- a/Clash/Provider/Media/JOOX.yaml
+++ b/Clash/Provider/Media/JOOX.yaml
@@ -1,5 +1,5 @@
 payload:  
   # > JOOX
-  # - User-Agent,WeMusic*
-  # - User-Agent,JOOX*
+  # - USER-AGENT,WeMusic*
+  # - USER-AGENT,JOOX*
   - DOMAIN-SUFFIX,joox.com

--- a/Clash/Provider/Media/KKTV.yaml
+++ b/Clash/Provider/Media/KKTV.yaml
@@ -1,7 +1,7 @@
 payload:  
   # > KKTV
-  # - User-Agent,KKTV*
-  # - User-Agent,com.kktv*
+  # - USER-AGENT,KKTV*
+  # - USER-AGENT,com.kktv*
   - DOMAIN-SUFFIX,kktv.me
   - DOMAIN-SUFFIX,kktv.com.tw
   - DOMAIN,kktv-theater.kk.stream

--- a/Clash/Provider/Media/Line TV.yaml
+++ b/Clash/Provider/Media/Line TV.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Line TV
-  # - User-Agent,LINE*
+  # - USER-AGENT,LINE*
   - DOMAIN-SUFFIX,d3c7rimkq79yfu.cloudfront.net
   - DOMAIN-SUFFIX,linetv.tw
   - DOMAIN-SUFFIX,profile.line-scdn.net

--- a/Clash/Provider/Media/MOO.yaml
+++ b/Clash/Provider/Media/MOO.yaml
@@ -1,4 +1,4 @@
 payload:  
   # > MOO
-  # - User-Agent,MOO*
-  # - User-Agent,TencentMidasConnect*
+  # - USER-AGENT,MOO*
+  # - USER-AGENT,TencentMidasConnect*

--- a/Clash/Provider/Media/Netflix.yaml
+++ b/Clash/Provider/Media/Netflix.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Netflix
-  # - PROCESS-NAME,Argo*
+  # - USER-AGENT,Argo*
   - DOMAIN-KEYWORD,netflix
   - DOMAIN,netflix.com.edgesuite.net
   - DOMAIN-SUFFIX,netflix.com

--- a/Clash/Provider/Media/PBS.yaml
+++ b/Clash/Provider/Media/PBS.yaml
@@ -1,4 +1,4 @@
 payload:  
   # > PBS
-  # - User-Agent,PBS*
+  # - USER-AGENT,PBS*
   - DOMAIN-SUFFIX,pbs.org

--- a/Clash/Provider/Media/Soundcloud.yaml
+++ b/Clash/Provider/Media/Soundcloud.yaml
@@ -1,5 +1,5 @@
 payload:  
   # > SoundCloud
-  # - User-Agent,SoundCloud*
+  # - USER-AGENT,SoundCloud*
   - DOMAIN-SUFFIX,sndcdn.com
   - DOMAIN-SUFFIX,soundcloud.com

--- a/Clash/Provider/Media/Spotify.yaml
+++ b/Clash/Provider/Media/Spotify.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Spotify
-  # - User-Agent,Spotify*
+  # - USER-AGENT,Spotify*
   - DOMAIN-SUFFIX,pscdn.co
   - DOMAIN-SUFFIX,scdn.co
   - DOMAIN-SUFFIX,spoti.fi

--- a/Clash/Provider/Media/ViuTV.yaml
+++ b/Clash/Provider/Media/ViuTV.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > ViuTV
-  # - User-Agent,ViuTV*
+  # - USER-AGENT,ViuTV*
   - DOMAIN-SUFFIX,bootstrapcdn.com
   - DOMAIN-SUFFIX,cloudfront.net
   - DOMAIN-SUFFIX,cognito-identity.us-east-1.amazonaws.com

--- a/Clash/Provider/Media/YouTube Music.yaml
+++ b/Clash/Provider/Media/YouTube Music.yaml
@@ -1,4 +1,4 @@
 payload:  
   # > Youtube Music
-  # - User-Agent,*YouTubeMusic*
-  # - User-Agent,*com.google.ios.youtubemusic*
+  # - USER-AGENT,*YouTubeMusic*
+  # - USER-AGENT,*com.google.ios.youtubemusic*

--- a/Clash/Provider/Media/YouTube.yaml
+++ b/Clash/Provider/Media/YouTube.yaml
@@ -1,7 +1,7 @@
 payload:  
   # > Youtube
-  # - User-Agent,*youtube*
-  # - User-Agent,YouTube*
+  # - USER-AGENT,*youtube*
+  # - USER-AGENT,YouTube*
   - DOMAIN-KEYWORD,youtube
   - DOMAIN,yt3.ggpht.com
   - DOMAIN-SUFFIX,googlevideo.com

--- a/Clash/Provider/Media/encoreTVB.yaml
+++ b/Clash/Provider/Media/encoreTVB.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > encoreTVB
-  # - User-Agent,encoreTVB*
+  # - USER-AGENT,encoreTVB*
   - DOMAIN-SUFFIX,encoretvb.com
   - DOMAIN,content.jwplatform.com
   - DOMAIN,videos-f.jwpsrv.com

--- a/Clash/Provider/Media/myTV SUPER.yaml
+++ b/Clash/Provider/Media/myTV SUPER.yaml
@@ -1,5 +1,5 @@
 payload:  
   # > myTV_SUPER
-  # - User-Agent,mytv*
+  # - USER-AGENT,mytv*
   - DOMAIN-SUFFIX,mytvsuper.com
   - DOMAIN-SUFFIX,tvb.com

--- a/Clash/Provider/Microsoft.yaml
+++ b/Clash/Provider/Microsoft.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > Microsoft
-  # - User-Agent,OneDrive*
+  # - USER-AGENT,OneDrive*
   - DOMAIN-KEYWORD,onedrive
   - DOMAIN-SUFFIX,azure.com
   - DOMAIN-SUFFIX,fabric.io

--- a/Clash/Provider/PayPal.yaml
+++ b/Clash/Provider/PayPal.yaml
@@ -1,6 +1,6 @@
 payload:  
   # > PayPal
-  # - User-Agent,PayPal*
+  # - USER-AGENT,PayPal*
   - DOMAIN-KEYWORD,paypal
   - DOMAIN-SUFFIX,paypal.com
   - DOMAIN-SUFFIX,paypalobjects.com

--- a/Clash/Provider/Proxy.yaml
+++ b/Clash/Provider/Proxy.yaml
@@ -23,7 +23,7 @@ payload:
   - DOMAIN-KEYWORD,tesla
 
   # > Zooba
-  # - User-Agent,battleroyale*
+  # - USER-AGENT,battleroyale*
 
   # > Top blocked sites
   - DOMAIN-SUFFIX,2o7.net
@@ -616,7 +616,7 @@ payload:
   - DOMAIN-SUFFIX,zynamics.com
 
   # > Force some domains which are fucked by GFW while resolving DNS,or do not respect the system Proxy
-  # - User-Agent,WhatsApp*
+  # - USER-AGENT,WhatsApp*
 
   - DOMAIN-KEYWORD,appledaily
   - DOMAIN-KEYWORD,beetalk

--- a/Clash/Provider/Special.yaml
+++ b/Clash/Provider/Special.yaml
@@ -3,8 +3,8 @@ payload:
   - DOMAIN-SUFFIX,dler.cloud
 
   # > Apple CDN
-  # - PROCESS-NAME,storedownloadd
-  # - User-Agent,com.apple.appstored*
+  - PROCESS-NAME,storedownloadd
+  # - USER-AGENT,com.apple.appstored*
   - DOMAIN,aod.itunes.apple.com
   - DOMAIN,api.smoot.apple.cn
   - DOMAIN,appldnld.apple.com
@@ -38,11 +38,11 @@ payload:
   - DOMAIN-SUFFIX,xboxlive.com
 
   # > Proxy plugin
-  # - PROCESS-NAME,v2ray
-  # - PROCESS-NAME,ss-local
+  - PROCESS-NAME,v2ray
+  - PROCESS-NAME,ss-local
 
   # > Steam
-  # - User-Agent,Steam*
+  # - USER-AGENT,Steam*
   - DOMAIN-SUFFIX,pinyuncloud.com
   - DOMAIN-SUFFIX,steamcontent.com
 
@@ -51,35 +51,34 @@ payload:
   - DOMAIN-SUFFIX,tesla-cdn.thron.cn
 
   # > UUBooster
-  # - PROCESS-NAME,UUBooster
+  - PROCESS-NAME,UUBooster
 
   # > Xunlei
-  # - User-Agent,%E8%BF%85%E9%9B%B7
+  # - USER-AGENT,%E8%BF%85%E9%9B%B7
   - DOMAIN-SUFFIX,xunlei.com
 
   # > Download
-  # - PROCESS-NAME,aria2c.exe
-  # - PROCESS-NAME,BitComet.exe
-  # - PROCESS-NAME,fdm.exe
+  - PROCESS-NAME,aria2c.exe
+  - PROCESS-NAME,BitComet.exe
+  - PROCESS-NAME,fdm.exe
   # - PROCESS-NAME,IDMan.exe
-  # - PROCESS-NAME,NetTransport.exe
-  # - PROCESS-NAME,qbittorrent.exe
-  # - PROCESS-NAME,Thunder.exe
-  # - PROCESS-NAME,ThunderVIP.exe
-  # - PROCESS-NAME,transmission-daemon.exe
-  # - PROCESS-NAME,transmission-qt.exe
-  # - PROCESS-NAME,uTorrent.exe
-  # - PROCESS-NAME,WebTorrent.exe
-  # - PROCESS-NAME,aria2c
-  # - PROCESS-NAME,fdm
-  # - PROCESS-NAME,Folx
-  # - PROCESS-NAME,NetTransport
-  # - PROCESS-NAME,qbittorrent
-  # - PROCESS-NAME,Thunder
-  # - PROCESS-NAME,Transmission
-  # - PROCESS-NAME,uTorrent
-  # - PROCESS-NAME,WebTorrent
-  # - PROCESS-NAME,WebTorrent Helper
+  - PROCESS-NAME,NetTransport.exe
+  - PROCESS-NAME,qbittorrent.exe
+  - PROCESS-NAME,Thunder.exe
+  - PROCESS-NAME,transmission-daemon.exe
+  - PROCESS-NAME,transmission-qt.exe
+  - PROCESS-NAME,uTorrent.exe
+  - PROCESS-NAME,WebTorrent.exe
+  - PROCESS-NAME,aria2c
+  - PROCESS-NAME,fdm
+  - PROCESS-NAME,Folx
+  - PROCESS-NAME,NetTransport
+  - PROCESS-NAME,qbittorrent
+  - PROCESS-NAME,Thunder
+  - PROCESS-NAME,Transmission
+  - PROCESS-NAME,uTorrent
+  - PROCESS-NAME,WebTorrent
+  - PROCESS-NAME,WebTorrent Helper
 
   # > Private Tracker
   - DOMAIN-SUFFIX,awesome-hd.me

--- a/Clash/Provider/Speedtest.yaml
+++ b/Clash/Provider/Speedtest.yaml
@@ -3,7 +3,7 @@ payload:
   - DOMAIN-SUFFIX,fast.com
 
   # > Speedtest by Ookla
-  # - User-Agent,SpeedTest*
+  # - USER-AGENT,SpeedTest*
   - DOMAIN-KEYWORD,speedtest
   - DOMAIN-SUFFIX,ooklaserver.net
 


### PR DESCRIPTION
Clash 规则集中绝大多数 PROCESS-NAME 规则原来在 Surge 规则集中也是 PROCESS-NAME 规则，因此是可以生效的，不应弃用。
另外统一了注释中 USER-AGENT 的大小写，修复了一点小问题。