### PR TITLE
Deprecate PROCESS-NAME rules for Telegram

### DIFF
--- a/Clash/Provider/Telegram.yaml
+++ b/Clash/Provider/Telegram.yaml
@@ -1,7 +1,7 @@
 payload:
   # > Telegram
-  - PROCESS-NAME,org.telegram.messenger
-  - PROCESS-NAME,Telegram
+  # - PROCESS-NAME,org.telegram.messenger
+  # - PROCESS-NAME,Telegram
   - DOMAIN-SUFFIX,t.me
   - DOMAIN-SUFFIX,tx.me
   - DOMAIN-SUFFIX,tdesktop.com


### PR DESCRIPTION
Telegram 不宜使用 PROCESS-NAME 规则，这可能导致其内置浏览器等分流错误