### PR TITLE
Update BBC iPlayer Rules

### DIFF
--- a/Clash/Provider/Media/BBC iPlayer.yaml
+++ b/Clash/Provider/Media/BBC iPlayer.yaml
@@ -2,7 +2,7 @@ payload:
   # > BBC iPlayer
   - PROCESS-NAME,bbc.iplayer.android
   - DOMAIN-KEYWORD,bbcfmt
-  - DOMAIN-KEYWORD,uk-live
+  - DOMAIN-KEYWORD,uk-live.akamaized
   - DOMAIN-SUFFIX,bbc.co
   - DOMAIN-SUFFIX,bbc.co.uk
   - DOMAIN-SUFFIX,bbc.com

--- a/Clash/Provider/Media/BBC iPlayer.yaml
+++ b/Clash/Provider/Media/BBC iPlayer.yaml
@@ -2,10 +2,7 @@ payload:
   # > BBC iPlayer
   - PROCESS-NAME,bbc.iplayer.android
   - DOMAIN-KEYWORD,bbcfmt
-  - DOMAIN,aod-dash-uk-live.akamaized.net
-  - DOMAIN,aod-hls-uk-live.akamaized.net
-  - DOMAIN,vod-dash-uk-live.akamaized.net
-  - DOMAIN,vod-thumb-uk-live.akamaized.net
+  - DOMAIN-KEYWORD,uk-live
   - DOMAIN-SUFFIX,bbc.co
   - DOMAIN-SUFFIX,bbc.co.uk
   - DOMAIN-SUFFIX,bbc.com


### PR DESCRIPTION
在Apple TV上测试抓包发现iplayer会访问这个域名：vod-hls-uk-live.akamaized.net
实测如果只添加这个域名，还是会有些抓包看不到的遗漏，导致部分剧无法播放，
结合现有的规则，猜测如果添加uk-live作为domain keyword则完全覆盖，实测添加这个domain keyword后也可以顺利播放所有剧集。